### PR TITLE
Remove requirement to restart server on Jenkins build.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,6 @@ Failed to restart Project Leo service for ${USER}.
 Do you have the following in your /etc/sudoers.d folder?
 $(whoami) ALL=NOPASSWD: /bin/systemctl start restart_project_leo@[a-z]*.service
 EOF
-              exit 1
             )
             '''
       }


### PR DESCRIPTION
This was preventing other branches that are not being served at projectleo.net from being built successfully.